### PR TITLE
Fixed padding in the power select

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -41,37 +41,6 @@
   }
 }
 
-// Custom ember power select component with pre-filled text in search
-
-$ember-power-select-border-color: #ccc !default;
-$ember-power-select-focus-border-color: #66afe9 !default;
-$ember-power-select-default-border: 1px solid $ember-power-select-border-color !default;
-$ember-power-select-search-field-border: $ember-power-select-default-border !default;
-$ember-power-select-search-input-border-radius: 3px !default;
-$ember-power-select-default-focus-border: 1px solid
-  $ember-power-select-focus-border-color !default;
-$ember-power-select-search-field-focus-border: $ember-power-select-default-focus-border !default;
-$ember-power-select-focus-box-shadow:
-  inset 0 1px 1px rgba(0, 0, 0, 0.075),
-  0 0 8px rgba(102, 175, 233, 0.6) !default;
-$ember-power-select-focus-outline: solid 2px rgb(16, 108, 200) !default;
-
-.ember-power-select-movable-cursor {
-  border: $ember-power-select-search-field-border;
-  border-radius: $ember-power-select-search-input-border-radius;
-  width: 100%;
-  font-size: inherit;
-  line-height: inherit;
-  padding: 0 5px;
-  &:focus {
-    border: $ember-power-select-search-field-focus-border;
-    box-shadow: $ember-power-select-focus-box-shadow;
-    @if $ember-power-select-focus-outline {
-      outline: $ember-power-select-focus-outline;
-    }
-  }
-}
-
 // For data display
 
 .grid-container-two-column-fixed {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,3 @@
-
 /* ==================================
    #APPUNIVERSUM
    ================================== */
@@ -18,7 +17,6 @@
  * UTILITIES: Single function helper classes (namespace: '.au-u-...')
  */
 
-
 // VARIABLES
 
 @import "ember-appuniversum/s-colors.scss";
@@ -30,16 +28,13 @@
 @import "ember-appuniversum/t-font-size";
 @import "ember-appuniversum/t-sass-mq";
 
-
 // GENERIC
 @import "ember-appuniversum/g-reset";
 @import "ember-appuniversum/g-box-sizing";
 @import "ember-appuniversum/g-font";
 
-
 // ELEMENTS
 @import "ember-appuniversum/e-page";
-
 
 // OBJECTS
 @import "ember-appuniversum/o-box";
@@ -47,7 +42,6 @@
 @import "ember-appuniversum/o-grid";
 @import "ember-appuniversum/o-layout";
 @import "ember-appuniversum/o-region";
-
 
 // COMPONENTS
 @import "ember-appuniversum/c-accordion";
@@ -102,7 +96,6 @@
 @import "ember-appuniversum/p-ember-power-select";
 @import "ember-appuniversum/p-duet-datepicker";
 
-
 // UTILITIES
 @import "ember-appuniversum/u-align-text";
 @import "ember-appuniversum/u-background";
@@ -121,6 +114,4 @@
 @import "ember-appuniversum/u-widths";
 
 // TEMPORARY HACKS AND QUICKFIXES
-@import 'shame';
-
-@import "ember-power-select";
+@import "shame";


### PR DESCRIPTION
## ID
[CLBV-152](https://binnenland.atlassian.net/browse/CLBV-152)

 ## Description

Power select components didn't have the right padding on the options. There was an import in app.scss that was causing this issue.

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Test this by going to the site edit page or new site page. There will be dropdowns for site type and countries. You can check there.

Edit: Be sure to go to the router.js file and uncomment the edit/new routes