### PR TITLE
Add legal pages

### DIFF
--- a/app/components/with-footer.hbs
+++ b/app/components/with-footer.hbs
@@ -1,0 +1,30 @@
+<AuMainFooter>
+  <AuHeading @level="3" @skin="4">
+    xxx.abb.vlaanderen.be is een officiële website van de Vlaamse overheid
+  </AuHeading>
+  <AuContent @skin="small">
+    <p>Uitgegeven door
+      <a
+        class="au-c-link"
+        href="https://www.vlaanderen.be/organisaties/administratieve-diensten-van-de-vlaamse-overheid/beleidsdomein-kanselarij-en-bestuur/agentschap-binnenlands-bestuur"
+      >Agentschap Binnenlands Bestuur</a>
+    </p>
+    <ul class="au-c-list-horizontal">
+      <li class="au-c-list-horizontal__item">
+        <AuLink @route="legal.disclaimer" @skin="secondary">Disclaimer</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink
+          @route="legal.cookiestatement"
+          @skin="secondary"
+        >Cookieverklaring</AuLink>
+      </li>
+      <li class="au-c-list-horizontal__item">
+        <AuLink
+          @route="legal.accessibilitystatement"
+          @skin="secondary"
+        >Toegankelijkheidsverklaring</AuLink>
+      </li>
+    </ul>
+  </AuContent>
+</AuMainFooter>

--- a/app/router.js
+++ b/app/router.js
@@ -18,6 +18,16 @@ Router.map(function () {
     this.route('switch');
   });
 
+  this.route('legal', { path: '/legaal' }, function () {
+    this.route('accessibilitystatement', {
+      path: '/toegangkelijkheidsverklaring',
+    });
+    this.route('cookiestatement', {
+      path: '/cookieverklaring',
+    });
+    this.route('disclaimer');
+  });
+
   this.route('core-data', { path: '/kerngegevens' }, function () {
     this.route('admin-unit', { path: '/bestuurseenheid' }, function () {
       this.route('index', { path: '/' });

--- a/app/routes/legal/accessibilitystatement.js
+++ b/app/routes/legal/accessibilitystatement.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class LegalAccessibilitystatementRoute extends Route {}

--- a/app/routes/legal/cookiestatement.js
+++ b/app/routes/legal/cookiestatement.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class LegalCookiestatementRoute extends Route {}

--- a/app/routes/legal/disclaimer.js
+++ b/app/routes/legal/disclaimer.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class LegalDisclaimerRoute extends Route {}

--- a/app/templates/legal/accessibilitystatement.hbs
+++ b/app/templates/legal/accessibilitystatement.hbs
@@ -1,0 +1,68 @@
+<AuContent class="au-o-region-large au-o-layout">
+  <AuHeading>Toegankelijkheidsverklaring</AuHeading>
+  <p>
+    Agentschap Binnenlands Bestuur streeft ernaar zijn websites en mobiele
+    applicaties toegankelijk te maken, overeenkomstig het
+    <AuLinkExternal
+      href="http://www.ejustice.just.fgov.be/eli/decreet/2018/12/07/2018032457/justel"
+    >Bestuursdecreet van 7 december 2018</AuLinkExternal>.
+  </p>
+  <p>Deze toegankelijkheidsverklaring is van toepassing op
+    <a
+      href="https://loket.lokaalbestuur.vlaanderen.be"
+      class="au-c-link"
+    >loket.lokaalbestuur.vlaanderen.be</a></p>
+  <h2>Nalevingsstatus</h2>
+  <p>Deze web applicatie voldoet gedeeltelijk aan de
+    <AuLinkExternal
+      href="https://www.w3.org/Translations/WCAG21-nl/"
+    >Richtlijnen voor Toegankelijkheid van Webcontent (WCAG) 2.1 Niveau AA</AuLinkExternal>,
+    omdat niet aan de onderstaande eis(en) is voldaan.</p>
+  <h2>Niet-toegankelijke inhoud</h2>
+  <ul>
+    <li>
+      <strong>Multiple select/Search select:</strong>
+      slechts een deel van select functionaliteit is toegankelijk via het
+      toetsenbord (<AuLinkExternal
+        href="https://www.w3.org/Translations/WCAG21-nl/#toetsenbord-geen-uitzondering"
+      >Succescriterium 2.1.3 Toetsenbord</AuLinkExternal>).
+      <br />
+      <em>Alternatief:</em>
+      de waarden kunnen manueel ingevoerd worden in het select input veld.
+    </li>
+  </ul>
+
+  <h2>Opstelling van deze toegankelijkheidsverklaring </h2>
+  <p>Deze toegankelijkheidsverklaring is opgesteld op 14/08/2020.</p>
+  <p>Voor deze toegankelijkheidsverklaring werd de toegankelijkheid van de
+    vermelde web applicatie beoordeeld door het Agentschap Binnenlands Bestuur.</p>
+
+  <h2>Feedback en contactgegevens</h2>
+  <p>Voor alle vragen en opmerkingen over de toegankelijkheid van de vermelde
+    websites van het Agentschap Binnenlands Bestuur kunt u contact opnemen via
+    <a
+      href="mailto:binnenland@vlaanderen.be"
+      class="au-c-link"
+    >binnenland@vlaanderen.be</a></p>
+
+  <h2>Handhavingsprocedure</h2>
+  <p>Bij onbevredigende antwoorden op uw vragen en opmerkingen kunt u de Vlaamse
+    Ombudsdienst contacteren via onderstaande gegevens.</p>
+  <p>
+    <strong>Vlaamse Ombudsdienst</strong><br />
+    Leuvenseweg 86
+    <br />
+    1000 Brussel
+    <br />
+    <a
+      href="mailto:info@vlaamseombudsdienst.be"
+      class="au-c-link"
+    >info@vlaamseombudsdienst.be</a>
+    <br />
+    Telefoon (gratis):
+    <a href="tel:info@vlaamseombudsdienst.be" class="au-c-link">1700</a>
+    <br />
+  </p>
+</AuContent>
+
+<WithFooter />

--- a/app/templates/legal/cookiestatement.hbs
+++ b/app/templates/legal/cookiestatement.hbs
@@ -1,0 +1,100 @@
+<AuContent class="au-o-region-large au-o-layout">
+  <AuHeading>Cookieverklaring</AuHeading>
+  <h2>Cookiebeleid van Agentschap Binnenlands Bestuur</h2>
+  <p>Agentschap Binnenlands Bestuur met maatschappelijke zetel te Havenlaan 88,
+    1000 Brussel is verantwoordelijk voor dit cookiebeleid. Agentschap
+    Binnenlands Bestuur vindt het belangrijk dat u op iedere plaats en elk
+    ogenblik haar content kan bekijken, beluisteren, lezen of beleven via
+    diverse mediaplatformen. Agentschap Binnenlands Bestuur wil ook werken aan
+    interactieve diensten en diensten op uw maat. Op Agentschap Binnenlands
+    Bestuur-onlinediensten worden technieken gehanteerd om dit mogelijk te
+    maken, bijvoorbeeld met behulp van cookies&nbsp;en&nbsp;scripts. Deze
+    technieken worden hierna gemakelijkheidshalve cookies genoemd.</p>
+  <p>In dit cookiebeleid wenst Agentschap Binnenlands Bestuur u te informeren
+    welke cookies worden gebruikt en waarom dit gebeurt. Verder wordt toegelicht
+    in welke mate u als gebruiker het gebruik kan controleren. Agentschap
+    Binnenlands Bestuur wil namelijk graag uw privacy en de
+    gebruiksvriendelijkheid van haar onlinediensten zoveel mogelijk waarborgen.
+    Agentschap Binnenlands Bestuur heeft geprobeerd dit beleid zo eenvoudig
+    mogelijk te houden.</p>
+  <p>Agentschap Binnenlands Bestuur kan het cookiebeleid&nbsp;op elk moment
+    veranderen. Dat kan bijvoorbeeld gebeuren in het kader van veranderingen aan
+    haar diensten of de geldende wetgeving. Het gewijzigde beleid wordt dan
+    bekendgemaakt op de relevante Agentschap Binnenlands Bestuur-onlinediensten
+    en gelden vanaf het moment dat deze bekendgemaakt wordt.&nbsp;</p>
+  <h3>Wat zijn cookies precies?</h3>
+  <p>Cookies zijn kleine gegevens- of tekstbestanden die op uw computer of
+    mobiele apparaat zijn geïnstalleerd wanneer u een website bezoekt of een
+    (mobiele) toepassing gebruikt. Het cookiebestand bevat een unieke code
+    waarmee u uw browser kunt herkennen tijdens het bezoek aan de online service
+    of tijdens opeenvolgende, herhaalde bezoeken. Cookies kunnen worden
+    geplaatst door de server van de website of applicatie die u bezoekt, maar
+    ook door servers van derden die al dan niet met deze website of applicatie
+    samenwerken.</p>
+  <p>Cookies maken over het algemeen de interactie tussen de bezoeker en de
+    website of applicatie gemakkelijker en sneller en helpen de bezoeker om te
+    navigeren tussen de verschillende delen van een website of applicatie.</p>
+  <h3>Hoe kan u het gebruik van cookies weigeren of beheren?</h3>
+  <p>U kunt de installatie van cookies weigeren via uw browserinstellingen. U
+    kunt op elk gewenst moment ook de reeds geïnstalleerde cookies van uw
+    computer of mobiele apparaat verwijderen, als volgt:</p>
+  <ul>
+    <li>Chrome:&nbsp;<AuLinkExternal
+        href="http://support.google.com/chrome/bin/answer.py?hl=nl&amp;answer=95647"
+      >http://support.google.com/chrome/bin/answer.py?hl=nl&amp;answer=95647</AuLinkExternal></li>
+    <li>Firefox:&nbsp;<AuLinkExternal
+        href="http://support.mozilla.org/nl/kb/cookies-in-en-uitschakelen-websites-voorkeuren?redirectlocale=nl&amp;redirectslug=Cookies+in-+en+uitschakelen"
+      >http://support.mozilla.org/nl/kb/cookies-in-en-uitschakelen-websites-voorkeuren?redirectlocale=nl&amp;redirectslug=Cookies+in-+en+uitschakelen</AuLinkExternal></li>
+    <li>Safari:&nbsp;<AuLinkExternal
+        href="http://support.apple.com/kb/PH5042"
+      >http://support.apple.com/kb/PH5042</AuLinkExternal></li>
+  </ul><p>Wanneer u cookies uitschakelt, moet u er rekening mee houden dat
+    bepaalde grafische elementen er misschien niet mooi uitzien, of dat u
+    bepaalde toepassingen niet kunt gebruiken. Hieronder vindt u een
+    gedetailleerde lijst van de soorten cookies die op de website gebruikt
+    worden.</p>
+  <h3>Gebruikte cookies</h3>
+  <ul>
+    <li>Sessiebeheer
+      <ul><li>Naam van cookie: proxy_session</li>
+        <li>Doel: identificatie van de gebruikerssessie. De cookie wordt gezet
+          door de mu-identifier component van het mu.semte.ch platform.</li>
+        <li>Cookie(s) geplaatst door:&nbsp;Vlaamse overheid</li>
+        <li>Ontvangers van de gegevens: Vlaamse overheid</li>
+        <li>Geldigheid: duur van de sessie</li>
+      </ul>
+    </li>
+    <li>Reverse proxy
+      <ul><li>Naam van cookie: VOGANONUSER</li>
+        <li>Doel: de Reverse Proxy van de Vlaamse overheid plaats dit cookie op
+          Vlaanderen.be om de goede uitvoering van de verzending van
+          communicatie over een elektronisch communicatienetwerk van de Vlaamse
+          overheid te verzekeren.</li>
+        <li>Cookie(s) geplaatst door:&nbsp;Vlaamse overheid</li>
+        <li>Ontvangers van de gegevens: Vlaamse overheid</li>
+        <li>Geldigheid: permanente cookies met een geldigheid van maximaal 24
+          uur</li>
+      </ul>
+    </li>
+    <li>Meten van gebruikersbezoek
+      <ul><li>Namen van cookies: _ga, _gid, _gat en _umtz, _umta
+          en&nbsp;gaClientId</li>
+        <li>Doel: Het gebruikersbezoek op Vlaanderen.be wordt via Google
+          Universal Analytics op geanonimiseerde gemeten om het informatieaanbod
+          op Vlaanderen.be te optimaliseren. De analytics cookies wordt via de
+          Global header en footer widget op Vlaanderen.be geplaatst. Google
+          Analytics is zo ingesteld dat het IP-adres niet wordt verwerkt, noch
+          gegegens worden gedeeld</li>
+        <li>Cookie(s) geplaatst door:&nbsp;De analytics cookies worden geplaatst
+          via het Widgets-platform dat de global header en footer aanbiedt
+          (widgets.vlaanderen.be) en niet rechtsreeks door Google.com. Het
+          Widgets-platform maakt hiervoor gebruik van het Google analytics
+          object om zelf ClientID's aan te maken.</li>
+        <li>Ontvanger(s) van de gegevens: Google</li>
+        <li>Geldigheid: permanente cookies met een geldigheid van maximaal 2
+          jaar</li>
+      </ul></li>
+  </ul>
+</AuContent>
+
+<WithFooter />

--- a/app/templates/legal/disclaimer.hbs
+++ b/app/templates/legal/disclaimer.hbs
@@ -1,0 +1,53 @@
+<AuContent class="au-o-region-large au-o-layout">
+  <AuHeading>Disclaimer</AuHeading>
+  <h2>Gebruik van de website</h2>
+  <p>De Vlaamse overheid besteedt veel aandacht en zorg aan haar websites, en
+    streeft ernaar dat alle informatie zo volledig, juist, begrijpelijk,
+    nauwkeurig en actueel mogelijk is. Ondanks alle inspanningen kan het
+    gebeuren dat de informatie niet volledig, juist, nauwkeurig, bijgewerkt is
+    of wordt weergegeven.</p>
+  <p>Als de informatie die u vindt op deze website of ontvangt via telefoon,
+    e-mail of sociale media tekortkomingen vertoont, zal de Vlaamse overheid al
+    het mogelijke doen om dat zo snel mogelijk recht te zetten. Als u
+    onjuistheden vaststelt, kan u met ons contact opnemen. Wij streven ernaar om
+    uw melding zo snel mogelijk te behandelen. De Vlaamse overheid spant zich
+    ook in om onderbrekingen van technische aard zo veel mogelijk te voorkomen.
+    De Vlaamse overheid kan echter niet garanderen dat de websit volledig vrij
+    is van onderbrekingen en andere technische problemen.</p>
+  <p>Het is mogelijk dat bepaalde inhoud van onze website kan gedownload worden.
+    Dit is steeds op eigen risico. Schade ten gevolge van verlies van data of
+    schade aan de computer valt volledig en uitsluitend onder de
+    verantwoordelijkheid van de gebruiker.</p>
+  <p>Derden, bezoekers aan de website en gebruikers van diensten moeten zich
+    onthouden van handelingen die het gebruik van de website in gevaar kunnen
+    brengen. Stel dat een dergelijke handelingen die goede werkingen en/of het
+    veilige karakter van de website en/of haar diensten in gedrang breng en/of
+    tot de gebrekkige toegankelijkheid.</p>
+  <h3>Inhoud en informatie op de website</h3>
+  <p>We besteden grote zorg aan de website en de informatie die erop staat. We
+    kunnen onze website en haar inhoud steeds wijzigen, aanvullen of
+    verwijderen. Toch kunnen we geen garanties geven omtrent de kwaliteit van de
+    informatie op onze website. Het is dus mogelijk dat de informatie onvolledig
+    is, niet accuraat en/of niet nuttig is. We zijn bijgevolg niet aansprakelijk
+    voor directe of indirecte schade ten gevolge van handelingen die de
+    gebruiken of bezoeker neemt op basis van de informatie op onze website. Zo
+    verschijnt er op de website ook informatie en bestanden afkomstig van derde
+    partijen. Deze derde partijen zijn zelf verantwoordelijk voor de kwaliteit
+    van deze inhoud en bestanden.</p>
+  <h3>Hyperlinks en verwijzingen</h3>
+  <p>Deze site bevat hyperlinks naar websites van andere overheden, instanties
+    en organisaties, en naar informatiebronnen die door derden worden beheerd.
+    De Vlaamse overheid beschikt voor deze sites over geen enkele technische of
+    inhoudelijke controle of zeggenschap en kan daarom geen enkele garantie
+    bieden over de volledigheid of juistheid van de inhoud en over de
+    beschikbaarheid van de websites en informatiebronnen.</p>
+
+  <h2>Bescherming van persoonsgegegevens</h2>
+  <p>De Vlaamse overheid hecht veel belang aan de bescherming van uw
+    persoonlijke levenssfeer. De gegevens worden steeds verwerkt in
+    overeenstemming met de bepalingen van de algemene verordening
+    gegevensbescherming (AVG), en met de bepalingen van de federale en Vlaamse
+    regelgeving over de bescherming van natuurlijke personen bij de verwerking
+    van persoonsgegevens.</p>
+</AuContent>
+<WithFooter />


### PR DESCRIPTION
Here is the PR that will add the legal pages. To test this you can go to : 
- `/legaal/cookieverklaring`
- `/legaal/toegangkelijkheidsverklaring`
- `/legaal/disclaimer`

I also made a component for the footer so we can reuse that.