### PR TITLE
Fixed minor styling issue

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -79,3 +79,7 @@
 .au-c-toolbar {
   flex-wrap: nowrap;
 }
+
+.help-text {
+  align-items: baseline;
+}

--- a/app/templates/sites/site/index.hbs
+++ b/app/templates/sites/site/index.hbs
@@ -7,7 +7,7 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Vestiging: {{@model.site.address.fullAddress}}</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
+      <:subtitle>{{@model.adminUnit.name}}</:subtitle>
       <:action>
         {{!-- <AuLink
           @route="sites.site.edit"


### PR DESCRIPTION
## ID
[CLBV-329](https://binnenland.atlassian.net/browse/CLBV-329)

 ## Description

Report back component wraps in a weird way with long addresses. Added `align-items:baseline` to the `help-text` class to keep the text in place. On the site detail page the adminUnit name was not displayed. I thought this could have impact on the responsiveness as it is in the same header as the report back component. This issue also got fixed. If it's preferred to do it in a separate PR please let me know. (I'm asking @lagartoverde in particular)

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## How to test

Go to `/vestigingen` and choose any site. When in the detail page, resize the screen and see how the report back component resizes.