### PR TITLE
Avoid showing classification of admin unit twice

### DIFF
--- a/app/templates/core-data/admin-unit/index.hbs
+++ b/app/templates/core-data/admin-unit/index.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Kerngegevens</:title>
-      <:subtitle>{{this.currentSession.fullName}}
+      <:subtitle>{{this.currentSession.group.name}}
         ({{this.currentSession.groupClassificationLabel}})</:subtitle>
       <:action>
         <ReportWrongData />

--- a/app/templates/sites/index.hbs
+++ b/app/templates/sites/index.hbs
@@ -1,7 +1,7 @@
 {{page-title "Vestigingen"}}
 <PageHeader class="au-o-box">
   <:title>Vestigingen</:title>
-  <:subtitle>{{this.currentSession.fullName}}
+  <:subtitle>{{this.currentSession.group.name}}
     ({{this.currentSession.groupClassificationLabel}})</:subtitle>
   <:action>
     {{! <AuLink


### PR DESCRIPTION
Also something to take into account, we were showing the full name of the account instead of the admin unit, this on mock login worked fine, but on real login it would have shown the name of the person, so good thing we catched that