### PR TITLE
Callback error message

### DIFF
--- a/app/controllers/sites/new.js
+++ b/app/controllers/sites/new.js
@@ -90,7 +90,6 @@ export default class CreateSitesNewController extends Controller {
     // Voeg de maxReachedMessage toe aan de foutmeldingen als het aantal site types dat wordt ingevoerd niet groter is dan het maximum
     if (maxReachedMessage) {
       errors['siteType'] = maxReachedMessage;
-      console.log('Ik ben er');
     }
 
     return {

--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function () {
 
   this.route('auth', { path: '/authorization' }, function () {
     this.route('callback');
+    this.route('callback-error');
     this.route('login');
     this.route('logout');
     this.route('switch');

--- a/app/routes/auth/callback-error.js
+++ b/app/routes/auth/callback-error.js
@@ -1,0 +1,3 @@
+import Route from '@ember/routing/route';
+
+export default class AuthCallbackRoute extends Route {}

--- a/app/routes/sites/index.js
+++ b/app/routes/sites/index.js
@@ -17,7 +17,7 @@ export default class ContactDataViewSiteRoute extends Route {
         primarySiteId: primarySite.id,
       };
     } catch (error) {
-      this.router.transitionTo('auth.logout');
+      this.router.transitionTo('auth.callback-error');
     }
   }
 }

--- a/app/templates/auth/callback-error.hbs
+++ b/app/templates/auth/callback-error.hbs
@@ -1,0 +1,16 @@
+{{page-title "Fout bij het aanmelden"}}
+
+{{! TODO: implement a better error page once Appuniversum provides a template example for it: https://github.com/appuniversum/ember-appuniversum/issues/384 }}
+<AuAlert @icon="circle-x" @skin="error" @title="Fout bij het aanmelden">
+  <p>
+    Er ging iets fout bij het aanmelden.
+    <AuLink @route="auth.login">Probeer het opnieuw</AuLink>.
+
+    <AuHelpText>
+      Indien dit probleem zich blijft voordoen, contacteer
+      <AuLinkExternal
+        href="https://overheid.vlaanderen.be/ict/ict-diensten/gebruikersbeheer"
+      >gebruikersbeheer Vlaanderen</AuLinkExternal>.
+    </AuHelpText>
+  </p>
+</AuAlert>

--- a/app/templates/auth/callback-error.hbs
+++ b/app/templates/auth/callback-error.hbs
@@ -4,7 +4,7 @@
 <AuAlert @icon="circle-x" @skin="error" @title="Fout bij het aanmelden">
   <p>
     Er ging iets fout bij het aanmelden.
-    <AuLink @route="auth.login">Probeer het opnieuw</AuLink>.
+    <AuLink @route="auth.switch">Probeer het opnieuw</AuLink>.
 
     <AuHelpText>
       Indien dit probleem zich blijft voordoen, contacteer


### PR DESCRIPTION
## ID
 [CLBV-435](https://binnenland.atlassian.net/browse/CLBV-435)

 ## Description

User gets redirected to an error page when organization has no access to the contactgegevens app.

 ## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other


 ## How to test

 Try to log in with an organization that has no access to contactgegevens. You will see the callback error. Press the try again button and it will redirect you again to the switch login route.