### PR TITLE
now address selector searches first for the current value

### DIFF
--- a/app/components/address-register-selector.hbs
+++ b/app/components/address-register-selector.hbs
@@ -14,6 +14,8 @@
     @disabled={{false}}
     @placeholder="Geef adres in"
     @onClose={{@onClose}}
+    @registerAPI={{this.powerselectApiRegistration}}
+    @onOpen={{this.searchForCurrentAddress}}
     as |suggestion|
 
   >

--- a/app/components/address-register-selector.js
+++ b/app/components/address-register-selector.js
@@ -4,6 +4,7 @@ import { task, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { combineFullAddress } from 'frontend-contactgegevens-loket/models/address';
 import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
+import { action } from '@ember/object';
 
 /**
  * @typedef {uri: string, addressRegisterId: string, fullAddress: string, street:string,housenumber:string,busNumber:string | null,zipCode:string,municipality:string,country:string | null} AddressSuggestion
@@ -12,6 +13,7 @@ import { task as trackedTask } from 'ember-resources/util/ember-concurrency';
 export default class AddressRegisterSelectorComponent extends Component {
   @service addressRegister;
   @service store;
+  powerselectApi;
 
   constructor() {
     super(...arguments);
@@ -19,7 +21,6 @@ export default class AddressRegisterSelectorComponent extends Component {
     this.addressRegister.setup({ endpoint: '/adresses-register' });
     if (this.args.address) {
       let addressSuggestion = this.args.address;
-
       if (!this.addressRegister.isEmpty(addressSuggestion)) {
         this.addressSuggestion = addressSuggestion;
       }
@@ -95,7 +96,20 @@ export default class AddressRegisterSelectorComponent extends Component {
     });
     this.options = options;
   });
+
+  @action
+  powerselectApiRegistration(api) {
+    this.powerselectApi = api
+  }
+  @action
+  searchForCurrentAddress() {
+    if(this.powerselectApi) {
+      this.powerselectApi.actions.search(this.addressSuggestion.fullAddress)
+    }
+  }
 }
+
+
 
 function addressInstanceToAddressSuggestion(addressInstance) {
   return {


### PR DESCRIPTION
So simple PR, the problem was that when the user clicked on the address search it didn't prefilled the current address so the changes now are that every time the powerselect is open it searches first for the current address.
The code changes are only a function that registers the powerselect API in the component and another that triggers on the open of the component, and performs the search.
Possible drawbacks of this solution is that sometimes the search is not needed if the user has clear that he wants to change it something else, but I think is good to provide the list of options the user had before like box numbers etc and performing another search assures that the info is up to date
CLBV-840