### PR TITLE
If there's no email, show niet opgegeven

### DIFF
--- a/app/components/site/contact-data-card.hbs
+++ b/app/components/site/contact-data-card.hbs
@@ -67,6 +67,13 @@
               {{@primaryContact.email}}
             </:content>
           </Item>
+        {{else}}
+          <Item>
+            <:label>E-mail</:label>
+            <:content>
+              Niet opgegeven
+            </:content>
+          </Item>
         {{/if}}
         {{#if @primaryContact.website}}
           <Item>


### PR DESCRIPTION
CLBV-807
Basically the functionality was missing from the email field