### PR TITLE
Update mock-login accounts label display

### DIFF
--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -29,8 +29,8 @@
                 <AuButton @skin="link" {{on "click" (fn this.login account)}}>
                   <strong>
                     {{account.user.firstName}}
-                    {{account.user.familyName}}
                     -&nbsp;
+                    {{account.user.familyName}}
                   </strong>
                 </AuButton>
               </div>


### PR DESCRIPTION
Minor update so that the mock login account names are displayed as `Classification - Name` instead of `Classification Name -`. The latter confused me into thinking there was an issue in the data when it was just a frontend thing.