### PR TITLE
Add switch-login to all environments

### DIFF
--- a/app/components/app-header.hbs
+++ b/app/components/app-header.hbs
@@ -28,11 +28,9 @@
         role="menu"
       >
 
-        {{#unless this.session.isControllerLoginSession}}
-          <AuLink @route="auth.switch" @icon="switch" role="menuitem">
-            Wissel van bestuurseenheid
-          </AuLink>
-        {{/unless}}
+        <AuLink @route="auth.switch" @icon="switch" role="menuitem">
+          Wissel van bestuurseenheid
+        </AuLink>
 
         <AuLink @route="auth.logout" @icon="logout" role="menuitem">
           Afmelden

--- a/app/router.js
+++ b/app/router.js
@@ -6,9 +6,9 @@ export default class Router extends EmberRouter {
 }
 Router.map(function () {
   this.route('login');
+  this.route('switch-login');
   if (ENV.controllerLogin !== 'true') {
     this.route('mock-login');
-    this.route('switch-login');
   } else {
     this.route('controller-login');
   }
@@ -17,6 +17,7 @@ Router.map(function () {
     this.route('callback');
     this.route('callback-error');
     this.route('login');
+    this.route('switch');
     this.route('logout');
     if (ENV.controllerLogin !== 'true') {
       if (
@@ -26,7 +27,6 @@ Router.map(function () {
       ) {
         this.route('mock-login');
       }
-      this.route('switch');
     } else {
       this.route('controller-login');
     }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -9,11 +9,7 @@ export default class LoketSessionService extends SessionService {
       ? this.data.authenticated.authenticator.includes('mock-login')
       : false;
   }
-  get isControllerLoginSession() {
-    return this.isAuthenticated
-      ? this.data.authenticated.authenticator.includes('controller-login')
-      : false;
-  }
+
   async handleAuthentication(routeAfterAuthentication) {
     // We wait for the currentSession to load before navigating. This fixes the empty index page since the data might not be loaded yet.
     await this.currentSession.load();

--- a/app/templates/auth/callback-error.hbs
+++ b/app/templates/auth/callback-error.hbs
@@ -4,9 +4,7 @@
 <AuAlert @icon="circle-x" @skin="error" @title="Fout bij het aanmelden">
   <p>
     Er ging iets fout bij het aanmelden.
-    {{#unless this.session.isControllerLoginSession}}
-      <AuLink @route="auth.switch">Probeer het opnieuw</AuLink>.
-    {{/unless}}
+    <AuLink @route="auth.switch">Probeer het opnieuw</AuLink>.
     <AuHelpText>
       Indien dit probleem zich blijft voordoen, contacteer
       <AuLinkExternal


### PR DESCRIPTION
# Context

[CLBV-1025]

Add the switch functionality to all environments, not only to mock-login.

Draft because there might be an acmidm misconfiguration, waiting for it to be cleared out.

# Test instructions

Here's how I did it but if you find an easier way go ahead :sweat_smile: 

- Request ACMIDM controle authorization to Sofie or Nele
- Setup locally your stack to run as if you were on https://controle.contactgegevens.lokaalbestuur.vlaanderen.be : see https://chat.semte.ch/group/NEgndwztFq7E3dcks?msg=FLA65MhoHQjf5KZdF
- Build the frontend: `docker build . -t contact-frontend:latest`
- Use the following config. It makes it such that your frontend and identifier will behave as the controle ones from prod
```
  frontend:
    image: contact-frontend:latest
    volumes:
      - ./config/frontend/add-x-frame-options-header.conf:/config/add-x-frame-options.conf
    environment:
      EMBER_ENABLE_EDIT_FEATURE: "false"
      EMBER_OAUTH_API_KEY: "SEE_PROD_OR_QA"
      EMBER_OAUTH_API_SCOPE: "openid rrn profile vo abb_loketcontactapp"
      EMBER_OAUTH_API_BASE_URL: "https://authenticatie.vlaanderen.be/op/v1/auth"
      EMBER_OAUTH_API_LOGOUT_URL: "https://authenticatie.vlaanderen.be/op/v1/logout"
      EMBER_OAUTH_API_REDIRECT_URL: "https://controle.contactgegevens.lokaalbestuur.vlaanderen.be/controller-login"
      EMBER_OAUTH_SWITCH_URL: "https://controle.contactgegevens.lokaalbestuur.vlaanderen.be/switch-login"
      EMBER_CONTROLLER_LOGIN: "true"
      EMBER_CONTROLLER_ROLECLAIM: "ControllerContactAPP"

  login:
    image: lblod/acmidm-login-service:0.9.2
    environment:
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://controle.contactgegevens.lokaalbestuur.vlaanderen.be/controller-login"
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "SEE_PROD_OR_QA"
      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_loketcontactapp_rol_3d"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "SEE_PROD_OR_QA"
```